### PR TITLE
removing library decoration from groovy script

### DIFF
--- a/vars/prUtils.groovy
+++ b/vars/prUtils.groovy
@@ -1,4 +1,3 @@
-@Library('prUtils')
 import groovy.json.JsonSlurper
 
 def findClosedPrs(prs) {


### PR DESCRIPTION
I think this might be why we were getting the library not found error